### PR TITLE
LFLT-547 Migrate all support library to Java 17 and Spring Boot 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 orbs:
-  jira: circleci/jira@1.1.2
+  jira: circleci/jira@1.3.1
 jobs:
   build_leaflet-oauth-support:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - run:

--- a/frontend-support/pom.xml
+++ b/frontend-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-oauth-support</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.0.1</version>
+        <version>1.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/frontend-support/src/main/java/hu/psprog/leaflet/oauth/frontend/filter/ExpiredSessionFilter.java
+++ b/frontend-support/src/main/java/hu/psprog/leaflet/oauth/frontend/filter/ExpiredSessionFilter.java
@@ -10,10 +10,10 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**

--- a/frontend-support/src/main/java/hu/psprog/leaflet/oauth/frontend/filter/device/DeviceIDFilter.java
+++ b/frontend-support/src/main/java/hu/psprog/leaflet/oauth/frontend/filter/device/DeviceIDFilter.java
@@ -6,10 +6,10 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import java.io.IOException;
 import java.util.UUID;
 

--- a/frontend-support/src/main/java/hu/psprog/leaflet/oauth/frontend/filter/device/DeviceIDGenerator.java
+++ b/frontend-support/src/main/java/hu/psprog/leaflet/oauth/frontend/filter/device/DeviceIDGenerator.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.WebApplicationContext;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import java.util.UUID;
 
 /**

--- a/frontend-support/src/main/java/hu/psprog/leaflet/oauth/frontend/logout/ForcedLogoutHandler.java
+++ b/frontend-support/src/main/java/hu/psprog/leaflet/oauth/frontend/logout/ForcedLogoutHandler.java
@@ -3,7 +3,7 @@ package hu.psprog.leaflet.oauth.frontend.logout;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.stream.Stream;
 
 /**

--- a/frontend-support/src/main/resources/META-INF/spring.factories
+++ b/frontend-support/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  hu.psprog.leaflet.oauth.frontend.config.JWTAuthenticationFrontEndSupportConfiguration

--- a/frontend-support/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/frontend-support/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+hu.psprog.leaflet.oauth.frontend.config.JWTAuthenticationFrontEndSupportConfiguration

--- a/frontend-support/src/test/java/hu/psprog/leaflet/oauth/frontend/filter/ExpiredSessionFilterTest.java
+++ b/frontend-support/src/test/java/hu/psprog/leaflet/oauth/frontend/filter/ExpiredSessionFilterTest.java
@@ -17,9 +17,9 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static org.mockito.Mockito.verify;

--- a/frontend-support/src/test/java/hu/psprog/leaflet/oauth/frontend/filter/device/DeviceIDFilterTest.java
+++ b/frontend-support/src/test/java/hu/psprog/leaflet/oauth/frontend/filter/device/DeviceIDFilterTest.java
@@ -8,9 +8,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.ServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletResponse;
 import java.io.IOException;
 import java.util.UUID;
 

--- a/frontend-support/src/test/java/hu/psprog/leaflet/oauth/frontend/logout/ForcedLogoutHandlerTest.java
+++ b/frontend-support/src/test/java/hu/psprog/leaflet/oauth/frontend/logout/ForcedLogoutHandlerTest.java
@@ -16,7 +16,7 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
-import javax.servlet.http.Cookie;
+import jakarta.servlet.http.Cookie;
 import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>leaflet-oauth-support</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
 
     <modules>
         <module>frontend-support</module>
@@ -15,13 +15,13 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>2.1-r2302.1</version>
+        <version>3.0-r2305.1</version>
     </parent>
 
     <properties>
 
         <!-- Java environment version -->
-        <java.version>11</java.version>
+        <java.version>17</java.version>
 
         <!-- Compiler settings -->
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
 - Minor code improvements and fixing issues caused by the migration
 - Changed stack base BOM version to 3.0-r2305.1
 - Bumped library version to 1.1.0