### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   jira: circleci/jira@2.2.0
-  jq: circleci/jq@3.0.2
 
 executors:
   java:

--- a/frontend-support/pom.xml
+++ b/frontend-support/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>leaflet-oauth-support</artifactId>
         <groupId>hu.psprog.leaflet</groupId>
-        <version>1.2.1</version>
+        <version>1.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/frontend-support/src/test/java/hu/psprog/leaflet/oauth/frontend/mock/MockedJWTUserSecurityContextFactory.java
+++ b/frontend-support/src/test/java/hu/psprog/leaflet/oauth/frontend/mock/MockedJWTUserSecurityContextFactory.java
@@ -1,5 +1,6 @@
 package hu.psprog.leaflet.oauth.frontend.mock;
 
+import org.jspecify.annotations.NonNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,7 +28,8 @@ public class MockedJWTUserSecurityContextFactory implements WithSecurityContextF
     private static final String REGISTRATION_ID = "leaflet";
 
     @Override
-    public SecurityContext createSecurityContext(WithMockedJWTUser withMockedJWTUser) {
+    @NonNull
+    public SecurityContext createSecurityContext(@NonNull WithMockedJWTUser withMockedJWTUser) {
 
         OAuth2User oAuth2User = prepareOAuthUser(withMockedJWTUser);
         Authentication authentication = new OAuth2AuthenticationToken(oAuth2User, Collections.emptyList(), REGISTRATION_ID);

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>leaflet-oauth-support</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.1</version>
+    <version>1.3.0</version>
 
     <modules>
         <module>frontend-support</module>
@@ -15,7 +15,7 @@
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>5.0-r2505.1</version>
+        <version>6.0-r2604.2</version>
     </parent>
 
     <properties>
@@ -42,11 +42,22 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
-                    <argLine>${argLine.surefire}</argLine>
+                    <argLine>${argLine.surefire} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                     <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>


### PR DESCRIPTION
 - Switched to stack base BOM v6.0-r2604.2
 - POM fixes (annotation processing and Mockito warnings)
 - Bumped library version to 1.3.0